### PR TITLE
Remove superfluous expectation symbol

### DIFF
--- a/chapter2-ddp.tex
+++ b/chapter2-ddp.tex
@@ -1277,7 +1277,7 @@ We prove by induction. For $\ttime=\tHorizon$, this holds by definition, as $\Va
 \begin{split}
         \Value_\ttime(\state) &= \min_{\action_\ttime} \state^\top Q_\ttime \state + \action_\ttime^\top R_\ttime \action_\ttime + \Value_{\ttime+1}(A_\ttime \state + B_\ttime \action_\ttime) \\
         &= \min_{\action_\ttime} \state^\top Q_\ttime \state + \action_\ttime^\top R_\ttime \action_\ttime + (A_\ttime \state + B_\ttime \action_\ttime)^\top P_{\ttime+1} (A_\ttime \state + B_\ttime \action_\ttime) \\
-        &= \state^\top Q_\ttime \state + (A_\ttime x)^\top P_{\ttime+1} (A_\ttime \state) + \min_{\action_\ttime} \action_\ttime^\top (R_\ttime + B_\ttime^\top P_{\ttime+1} B_\ttime) \action_\ttime + 2(A_\ttime \state)^\top P_{\ttime+1} (B_\ttime \action_\ttime)
+        &= \state^\top Q_\ttime \state + (A_\ttime \state)^\top P_{\ttime+1} (A_\ttime \state) + \min_{\action_\ttime} \action_\ttime^\top (R_\ttime + B_\ttime^\top P_{\ttime+1} B_\ttime) \action_\ttime + 2(A_\ttime \state)^\top P_{\ttime+1} (B_\ttime \action_\ttime)
 \end{split}
 \end{equation*}
 The objective is quadratic in $\action_\ttime$, and solving the minimization gives 

--- a/chapter2-ddp.tex
+++ b/chapter2-ddp.tex
@@ -305,9 +305,9 @@ $\policy$, and the probability and expectation are taken with
 respect to the randomness of the policy $\policy$. Now we can
 rewrite the expected cost to go as,
 \[
-\E[\Cost^\policy(\state_0)]=\E[\sum_{\ttime=1}^{\tHorizon-1}
+\E[\Cost^\policy(\state_0)]=\sum_{\ttime=1}^{\tHorizon-1}
 \sum_{\action\in \Actions_\ttime,\state\in \States_\ttime}
-\cost_\ttime(\state,\action)\rho^\pi_\ttime(\state,\action)],
+\cost_\ttime(\state,\action)\rho^\pi_\ttime(\state,\action),
 \]
 where $\Cost^\policy(\state_0)$ is the random variable of the cost
 when starting at state $\state_0$ and following policy $\policy$.


### PR DESCRIPTION
What's written on the RHS is the definition of expectation, no need to write the E