### PR TITLE
corrections to chapter 2

### DIFF
--- a/chapter2-ddp.tex
+++ b/chapter2-ddp.tex
@@ -1045,6 +1045,7 @@ Obviously, we cannot expect the estimate $\heur(\nodev)$ to be exact -- if we kn
 
 \begin{definition}
 A heuristic is said to be \textbf{consistent} if for every adjacent vertices $\nodeu,\nodev$ we have that $$\cost(\nodev,\nodeu)+\heur[\nodeu]-\heur[\nodev] \geq 0.$$
+$$\heur[\nodev_d]=0$$  
 A heuristic is said to be \textbf{admissible} if it is a lower bound of the shortest path to the goal, i.e., for every vertex $\nodeu$ we have that $$\heur[\nodeu] \leq \minlen[\nodeu,\nodev_d],$$
 where we recall that $\minlen[\nodeu,\nodev]$ denotes the length of the shortest path between $\nodeu$ and $\nodev$.
 \end{definition}
@@ -1209,8 +1210,7 @@ negative cycles. We now consider the formula,
 Therefore we have
 \[
 \mu^*=\Delta=\min_{v\in V} \max_{0\leq k\leq n-1}
-\{\frac{d_n(v)-d_{\ttime}
-(v)}{n-k}\}
+\{\frac{d_n(v)-d_{k}(v)}{n-k}\}   
 \]
 which completes the proof.
 \end{proof}


### PR DESCRIPTION
Hi Aviv,

I found one typo and one missing definition.

First of all in Chapter 2 page 30 in the definition of the consistent heuristic, I believe you need to also add:
h[v_d]=0 
otherwise the first inequality is not enough to get admissibility.

second in chapter 2 page 33, in the proof of average cost. I believe in the last equation is should be:
d_n(v) - d_k(v)  and not  d_n(v) - d_t(v)

I have changed both those things.

Have a good week.

Asaf Gendler

301727715