### PR TITLE
Fix longest increasing subsequence example recursive formula in appen…

### DIFF
--- a/current_chapters/appendix-dp.tex
+++ b/current_chapters/appendix-dp.tex
@@ -77,7 +77,7 @@ Then
     {\Value_1} &= 1, \\
     \Value_{\ttime} &= \left\{\begin{array}{ll}
   1, & \text{if } x_{\ttime'}\geq x_{\ttime} \text{ for all } \ttime'<\ttime, \\
-  \max \left\{{\value_{\ttime'} : \ttime'<\ttime, x_{\ttime'}<x_{\ttime}}\right\}+1,& \text{else}. \end{array}\right. 
+  \max \left\{{\Value_{\ttime'} : \ttime'<\ttime, x_{\ttime'}<x_{\ttime}}\right\}+1,& \text{else}. \end{array}\right. 
 \end{split}
 \end{equation*}
 


### PR DESCRIPTION
…dix A.

The 'V' disappeared because '\Value' was used with small 'v' and not capital.